### PR TITLE
Adding a parameter to specify whether or not to drop the database after building it

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ This action uses [Flyway](https://flywaydb.org/) to spin up the specified databa
 ## Inputs
 | Parameter                       | Is Required  | Default | Description  |
 | --------------------------------|--------------|---------|--------------|
-| `db-server-name`                | true         | N/A     |The name of the database server to build the database on. |
-| `db-name`                       | true         | N/A     |The name of the database to build. |
-| `install-mock-db-objects`       | false        | false   |Specifies whether mock db objects should be used to fill out dependencies. If set to true mock-db-object-nuget-feed-url must also be set, otherwise an error will occur. |
-| `mock-db-object-nuget-feed-url` | false        | N/A     |The url to the nuget feed containing the mock database objects. This needs to be set if the install-mock-db-objects flag is set to avoid errors. |
-| `incremental`                   | false        | false   |Specifies whether to drop and recreate the database before building, or apply to the current database. |
-| `run-tests`                     | false        | false   |Specifies whether or not to run tSQLt tests. |
+| `db-server-name`                | true         | N/A     | The name of the database server to build the database on. |
+| `db-name`                       | true         | N/A     | The name of the database to build. |
+| `install-mock-db-objects`       | false        | false   | Specifies whether mock db objects should be used to fill out dependencies. If set to true mock-db-object-nuget-feed-url must also be set, otherwise an error will occur. |
+| `mock-db-object-nuget-feed-url` | false        | N/A     | The url to the nuget feed containing the mock database objects. This needs to be set if the install-mock-db-objects flag is set to avoid errors. |
+| `incremental`                   | false        | false   | Specifies whether to drop and recreate the database before building, or apply to the current database. |
+| `run-tests`                     | false        | false   | Specifies whether or not to run tSQLt tests. |
+| `drop-db-after-build`           | false        | true    | Specifies whether or not to drop the database after building. Set this to false if other steps in the job rely on the database existing. |
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
           version: 7.2.0
 
       - name: Build Database
-        uses: im-open/build-database-ci-action@v1.0.0
+        uses: im-open/build-database-ci-action@v1.0.1
         with:
           db-server-name: localhost
           db-name: MyLocalDB
@@ -38,6 +38,7 @@ jobs:
           mock-db-object-nuget-feed-url: https://www.nuget.org/
           incremental: false
           run-tests: true
+          drop-db-after-build: false
 ```
 
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,9 @@ inputs:
   run-tests:
     description: Specifies whether or not to run tests.
     default: false
+  drop-db-after-build:
+    description: Specifies whether or not to drop the database after building. Set this to false if other steps in the job rely on the database existing.
+    default: true
 
 runs:
   using: "composite"
@@ -34,4 +37,5 @@ runs:
         ${{ github.action_path }}/scripts/build-flyway.ps1 -dbServerName "${{ inputs.db-server-name }}" `
         -dbName "${{ inputs.db-name }}" -installMockDbObjects:$${{ inputs.install-mock-db-objects }} `
         -mockDbObjectNugetFeedUrl "${{ inputs.mock-db-object-nuget-feed-url }}" `
-        -incremental:$${{ inputs.incremental }} -runTests:$${{ inputs.run-tests }}
+        -incremental:$${{ inputs.incremental }} -runTests:$${{ inputs.run-tests }} `
+        -dropDbAfterBuild:$${{ inputs.drop-db-after-build }}

--- a/scripts/build-flyway.ps1
+++ b/scripts/build-flyway.ps1
@@ -3,6 +3,7 @@ param(
     [switch]$runTests, #Dictates whether or not the tests are run
     [string]$dbName,
     [switch]$installMockDbObjects,
+    [switch]$dropDbAfterBuild,
     [string]$mockDbObjectNugetFeedUrl,
     [string]$dbServerName = "localhost"
 )
@@ -54,6 +55,6 @@ Write-Host "Building database..."
 
 # Dot source the DMFlyway file so its functions can be used
 . $PSScriptRoot\database-management\DMFlyway.ps1
-Invoke-DatabaseBuild -incremental:$incremental -runTests:$runTests -runAllMigrations -hostName $dbServerName -installMockDbObjects:$installMockDbObjects -mockDbObjectNugetFeedUrl $mockDbObjectNugetFeedUrl -seedData -dropDbAfterBuild
+Invoke-DatabaseBuild -incremental:$incremental -runTests:$runTests -runAllMigrations -hostName $dbServerName -installMockDbObjects:$installMockDbObjects -mockDbObjectNugetFeedUrl $mockDbObjectNugetFeedUrl -seedData -dropDbAfterBuild:$dropDbAfterBuild
 
 # $VerbosePreference = $oldverbose


### PR DESCRIPTION
This is useful for jobs that need to do something with the database after it exists. This could include making snapshots of database objects, building backup files, etc.