### PR TITLE
Fixing bug with empty nuget password

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
           version: 7.2.0
 
       - name: Build Database
-        uses: im-open/build-database-ci-action@v1.0.4
+        uses: im-open/build-database-ci-action@v1.0.5
         with:
           db-server-name: localhost
           db-name: MyLocalDB

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Build Database
       shell: pwsh
       run: |
-        $securePassword = ConvertTo-SecureString "${{ inputs.nuget-password }}" -AsPlainText -Force
+        $securePassword = if(!!"${{ inputs.nuget-password }}") { ConvertTo-SecureString "${{ inputs.nuget-password }}" -AsPlainText -Force } else { $null }
 
         ${{ github.action_path }}/scripts/build-flyway.ps1 `
         -dbServerName "${{ inputs.db-server-name }}" `


### PR DESCRIPTION
Empty strings can't be turned into SecureStrings ☹️  