### PR TITLE
ARCH-1615 - Update syntax for setting outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ jobs:
           version: 7.2.0
 
       - name: Build Database
-        uses: im-open/build-database-ci-action@v3.0.5
+        uses: im-open/build-database-ci-action@v3.1.0
         with:
           db-server-name: localhost
           db-server-port: 1433

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
           $useIntegratedSecurity = "true"
         }
 
-        echo "::set-output name=use_integrated_security::$useIntegratedSecurity"
+        echo "use_integrated_security=$useIntegratedSecurity" >> $GITHUB_OUTPUT
 
     - name: Install SQL Powershell Module
       shell: pwsh

--- a/action.yml
+++ b/action.yml
@@ -85,7 +85,7 @@ runs:
           $useIntegratedSecurity = "true"
         }
 
-        echo "use_integrated_security=$useIntegratedSecurity" >> $GITHUB_OUTPUT
+        "use_integrated_security=$useIntegratedSecurity" >> $env:GITHUB_OUTPUT
 
     - name: Install SQL Powershell Module
       shell: pwsh


### PR DESCRIPTION
# Summary of PR changes

-  Update syntax for setting outputs to comply with the [GitHub's new recommendations](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands) to avoid logging untrusted data.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The examples in the repository's `README.md` have been updated with the new version.  
  - See the *Incrementing the Version* section of the repository's README.md for more details on how the version will be incremented.
- [x] The action code does not contain sensitive information.
