### PR TITLE
Remove quotes around filesystem locations

### DIFF
--- a/src/run-flyway/run-flyway-migrate.ps1
+++ b/src/run-flyway/run-flyway-migrate.ps1
@@ -21,7 +21,7 @@ Write-Information -InformationAction Continue -MessageData "Running migrate..."
 
 $resolvedPaths = New-Object -TypeName "System.Collections.ArrayList"
 $pathToMigrationFiles.Split(",") | ForEach-Object {
-    $resolvedPaths.Add("filesystem:`"$(Resolve-Path $_)`"")
+    $resolvedPaths.Add("filesystem:$(Resolve-Path $_)")
 }
 
 $flywayLocations = $resolvedPaths -Join ','


### PR DESCRIPTION
Removing these quotes allowed my flyway migrations which contained two different folders to run on a linux runner. 

Before this change flyway produced an error saying the migration locations weren't found and the migrations didn't run successfully.

# Summary of PR changes



## PR Requirements
- [ ] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [ ] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
